### PR TITLE
Fix: Correct date comparison and update claims count display

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,7 +53,6 @@ from components.notifications import init_notification_manager
 from components.notification_bell import render_notification_bell
 from components.auth import has_permission, check_authentication, render_login
 from components.new_navigation import render_main_navigation, render_user_info
-from components.ui import breadcrumb, metric_card, card, badge, loading_indicator
 from utils.helpers import show_warning, show_error, show_success, show_info, format_phone_number, format_dni, get_current_datetime, format_datetime, truncate_text, is_valid_email, safe_float_conversion, safe_int_conversion, get_status_badge, format_currency, get_breadcrumb_icon
 
 # Utils

--- a/components/reclamos/gestion.py
+++ b/components/reclamos/gestion.py
@@ -36,8 +36,8 @@ def render_gestion_reclamos(df_reclamos, df_clientes, sheet_reclamos, user):
     _render_desconexiones(df_reclamos, sheet_reclamos)
 
 def _render_conteo_por_tipo(df_reclamos):
-    """Muestra el conteo de reclamos pendientes y en curso, por tipo."""
-    st.subheader("📈 Conteo por Tipo de Reclamo")
+    """Muestra el conteo total de reclamos activos (pendientes y en curso), por tipo."""
+    st.subheader("📈 Conteo de Reclamos Activos por Tipo")
 
     df_activos = df_reclamos[df_reclamos["Estado"].isin(["Pendiente", "En curso"])]
 
@@ -45,15 +45,10 @@ def _render_conteo_por_tipo(df_reclamos):
         st.info("No hay reclamos activos (pendientes o en curso).")
         return
 
-    conteo = df_activos.groupby(["Tipo de reclamo", "Estado"]).size().unstack(fill_value=0)
+    conteo = df_activos.groupby("Tipo de reclamo").size().reset_index(name="Total Activos")
+    conteo.rename(columns={"Tipo de reclamo": "Tipo de Reclamo"}, inplace=True)
 
-    # Asegurarse que las columnas 'Pendiente' y 'En curso' existan
-    if "Pendiente" not in conteo:
-        conteo["Pendiente"] = 0
-    if "En curso" not in conteo:
-        conteo["En curso"] = 0
-
-    st.dataframe(conteo[["Pendiente", "En curso"]], use_container_width=True)
+    st.dataframe(conteo, use_container_width=True, hide_index=True)
 
 def _render_ultimos_reclamos(df_ultimos):
     """Muestra una lista filtrable de los últimos reclamos."""

--- a/components/resumen_jornada.py
+++ b/components/resumen_jornada.py
@@ -20,11 +20,18 @@ def render_resumen_jornada(df_reclamos):
         df_copy["Fecha y hora"] = pd.to_datetime(df_copy["Fecha y hora"], errors='coerce')
 
         argentina_tz = pytz.timezone("America/Argentina/Buenos_Aires")
-        hoy = datetime.now(argentina_tz).date()
 
-        # Filtrar reclamos de hoy
+        # Filtrar reclamos de hoy de forma robusta
         df_copy.dropna(subset=["Fecha y hora"], inplace=True)
-        df_hoy = df_copy[df_copy["Fecha y hora"].dt.tz_localize(argentina_tz).dt.date == hoy].copy()
+
+        now_arg = datetime.now(argentina_tz)
+        start_of_day = now_arg.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_of_day = start_of_day + timedelta(days=1)
+
+        # Localiza la columna de fecha a la zona horaria correcta antes de comparar
+        localized_dates = df_copy["Fecha y hora"].dt.tz_localize(argentina_tz, ambiguous='infer')
+
+        df_hoy = df_copy[(localized_dates >= start_of_day) & (localized_dates < end_of_day)].copy()
 
         # --- Cálculos de Métricas ---
         total_hoy = len(df_hoy)


### PR DESCRIPTION
This commit addresses two issues reported by the user:

1.  A `TypeError` in the daily summary component (`resumen_jornada.py`) caused by an invalid comparison between datetime objects. The date filtering logic has been updated to use a more robust, timezone-aware range comparison, which resolves the bug.
2.  The claim count in the 'Gestión de Reclamos' page (`gestion.py`) has been simplified. It now displays a single, aggregated total of active claims ('Pendiente' and 'En curso') for each claim type, rather than separate counts for each status.

Additionally, a minor code hygiene issue was fixed by removing an unused import statement from `app.py`.