### PR TITLE
Feat: Update claims management and fix summary bug

### DIFF
--- a/components/resumen_jornada.py
+++ b/components/resumen_jornada.py
@@ -19,33 +19,17 @@ def render_resumen_jornada(df_reclamos):
         df_copy = df_reclamos.copy()
         df_copy["Fecha y hora"] = pd.to_datetime(df_copy["Fecha y hora"], errors='coerce')
 
-        argentina_tz = pytz.timezone("America/Argentina/Buenos_Aires")
-
-        # Filtrar reclamos de hoy de forma robusta
-        df_copy.dropna(subset=["Fecha y hora"], inplace=True)
-
-        now_arg = datetime.now(argentina_tz)
-        start_of_day = now_arg.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_of_day = start_of_day + timedelta(days=1)
-
-        # Localiza la columna de fecha a la zona horaria correcta antes de comparar
-        localized_dates = df_copy["Fecha y hora"].dt.tz_localize(argentina_tz, ambiguous='infer')
-
-        df_hoy = df_copy[(localized_dates >= start_of_day) & (localized_dates < end_of_day)].copy()
-
         # --- Cálculos de Métricas ---
-        total_hoy = len(df_hoy)
         pendientes_total = len(df_copy[df_copy["Estado"] == "Pendiente"])
         en_curso_total = len(df_copy[df_copy["Estado"] == "En curso"])
         desconexion_total = len(df_copy[df_copy["Estado"] == "Desconexión"])
 
         # --- Visualización de Métricas ---
-        st.markdown("##### Resumen de Estado")
-        cols = st.columns(4)
-        cols[0].metric("📝 Reclamos de Hoy", total_hoy)
-        cols[1].metric("⏳ Pendientes (Total)", pendientes_total)
-        cols[2].metric("🔧 En Curso (Total)", en_curso_total)
-        cols[3].metric("🔌 Desconexión (Total)", desconexion_total)
+        st.markdown("##### Resumen de Estado General")
+        cols = st.columns(3)
+        cols[0].metric("⏳ Pendientes (Total)", pendientes_total)
+        cols[1].metric("🔧 En Curso (Total)", en_curso_total)
+        cols[2].metric("🔌 Desconexión (Total)", desconexion_total)
 
         st.markdown("---")
 


### PR DESCRIPTION
This commit implements user requests to update the 'Gestión de Reclamos' page and resolves a persistent bug in the daily summary component.

Key changes:
- In `components/reclamos/gestion.py`:
  - The list of recent claims now displays up to 100 results instead of 20.
  - The section for managing 'Desconexión a Pedido' has been completely replaced with a new, more detailed UI provided by the user, including a new helper function to mark claims as resolved.
- In `components/resumen_jornada.py`:
  - To resolve a persistent `TypeError` related to date comparisons, the 'Reclamos de Hoy' metric has been removed as per the user's suggestion. The component now only displays the total counts for 'Pendiente', 'En curso', and 'Desconexión'.
- In `app.py`:
    - The `KeyError` has been fixed by ensuring the `Teléfono` column is properly merged from `df_clientes` before rendering the claims table.
- In `utils/styles.py`:
    - The app width has been slightly reduced for better readability on wider screens.
- In `components/reclamos/impresion.py`:
    - The layout of the printing options has been changed to a 2x3 grid.
- In `components/new_navigation.py`:
    - The navigation labels have been shortened to single words.